### PR TITLE
accept two arguments for process

### DIFF
--- a/mock-kue.js
+++ b/mock-kue.js
@@ -16,8 +16,10 @@ kue.Job.prototype.save = function(fn){
 }
 
 kue.prototype.process = function(type, n, fn){
+	if ('function' == typeof n) fn = n, n = 1;
+
 	jobsProcessor[type] = fn;
-}	
+}
 
 kue.jobCount = function(){
 	return mockJobs.length;


### PR DESCRIPTION
Accept two arguments in jobs.process(type, n, fn), with n defaulting to 1

Taken from https://github.com/LearnBoost/kue/blob/master/lib/kue.js
