### PR TITLE
Mock a successful job save by calling the callback without arguments.

### DIFF
--- a/mock-kue.js
+++ b/mock-kue.js
@@ -11,7 +11,7 @@ kue.Job.prototype.save = function(fn){
 	this.id = mockJobs.length;
 	mockJobs.push(this);
 	if(fn){
-		fn(this);
+		fn();
 	}
 }
 


### PR DESCRIPTION
Fixes issue #2.
