### PR TITLE
Add getJobs() as shown in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ To get the access to created jobs, call the `.getJobs()` method:
 jobs.create(...).save();
 jobs.create(...).save();
 kue.jobCount(); // -> '2'
-kue.getJobs(); // -> rturns the array of created jobs
+kue.getJobs(); // -> returns the array of created jobs
 ```
 
 ## License

--- a/mock-kue.js
+++ b/mock-kue.js
@@ -23,6 +23,10 @@ kue.jobCount = function(){
 	return mockJobs.length;
 }
 
+kue.getJobs = function () {
+    return mockJobs;
+};
+
 kue.drain = function(){
 	var promises = [];
 	var self = this;


### PR DESCRIPTION
The README shows the getJobs() function which returns the array of saved jobs. This is useful in tests for ensuring the saved jobs are created with the correct data. This commit adds the missing functionality.
